### PR TITLE
Remove unneeded test dependencies to fix build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,3 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-}


### PR DESCRIPTION
This fix removes test dependencies that appear not to be needed.

Prior to this proposed change, a 'gradle clean build' would fail with:

```
➜  CryptoAPI-Bench git:(master) ✗ gradle clean build                                                                             git:(master|…5
Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/home/jonesn/src/CryptoAPI-Bench/build.gradle' line: 15

* What went wrong:
A problem occurred evaluating root project 'rigorityj-samples'.
> Could not find method testCompile() for arguments [{group=junit, name=junit, version=4.12}] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 4s
```

The cause was JUnit dependencies that appear not to be used, so this fix removes them

I did also consider proposing adding the gradle wrapper, however I note these are explicitly excluded in the gitignore so have left is. I can add this if required.